### PR TITLE
Fix Conda CI

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        miniforge-variant: Mambaforge
+        miniforge-version: latest
         use-mamba: true
         activate-environment: paretobench
     - name: Set cache date


### PR DESCRIPTION
This PR addresses the deprecation of the miniforge variant of the conda installer: https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/.