### PR TITLE
Add `__repr__` Method to `Problem`

### DIFF
--- a/src/paretobench/problem.py
+++ b/src/paretobench/problem.py
@@ -181,7 +181,13 @@ class Problem(BaseModel):
         # We are called from a child class; load parameters and create
         else:
             return cls(**loads(s))
-            
+    
+    def __repr__(self):
+        return self.to_line_fmt()
+    
+    def __str__(self):
+        return self.__repr__()
+
 
 class ProblemWithPF:
     """


### PR DESCRIPTION
This PR adds a `__repr__` function to the `Problem` class so that printing them gives reasonable output. I added `__str__` too as I have had pydantic not use `__repr__` in some instances in the past.