### PR TITLE
Add `__len__` to `History`

### DIFF
--- a/src/paretobench/containers.py
+++ b/src/paretobench/containers.py
@@ -551,6 +551,9 @@ class History(BaseModel):
     def __str__(self):
         return self.__repr__()
 
+    def __len__(self):
+        return len(self.reports)
+
 
 class Experiment(BaseModel):
     """

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -49,6 +49,7 @@ def test_empty_history():
 
         # Load the experiment from the file and compare with original
         loaded_experiment = Experiment.load(file_path)
+        assert len(experiment.runs[0]) == 0
         assert experiment == loaded_experiment, "The loaded experiment is not equal to the original experiment."
 
 


### PR DESCRIPTION
This PR adds the method `__len__` to history objects. It returns the number of reports included in the history.