### PR TITLE
Fix Workflows Cache Issue

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
         echo "CACHE_NUMBER=1" >> $GITHUB_ENV
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ${{ env.CONDA }}/envs
         key: conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}


### PR DESCRIPTION
This PR bumps up the version of the Github cache action to keep the testing workflow operating.